### PR TITLE
Feat [#15] Main App 파일 View 전환 로직 구현

### DIFF
--- a/HMH_iOS/HMH_iOS.xcodeproj/project.pbxproj
+++ b/HMH_iOS/HMH_iOS.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		0B3C29712BA01C3000435B30 /* MyPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B3C29702BA01C3000435B30 /* MyPageView.swift */; };
 		0B3C29732BA01DCE00435B30 /* CustomTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B3C29722BA01DCE00435B30 /* CustomTabView.swift */; };
 		0B7646BB2BB13F6100C56D7A /* SurveyButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B7646BA2BB13F6100C56D7A /* SurveyButton.swift */; };
+		0B9834DC2BC8234700A1457A /* SplashView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B9834DB2BC8234700A1457A /* SplashView.swift */; };
 		0B9ACF362BA14FDB00EC0BDE /* Main-F-final.json in Resources */ = {isa = PBXBuildFile; fileRef = 0B9ACF302BA14FDB00EC0BDE /* Main-F-final.json */; };
 		0B9ACF372BA14FDB00EC0BDE /* Main-B-final.json in Resources */ = {isa = PBXBuildFile; fileRef = 0B9ACF312BA14FDB00EC0BDE /* Main-B-final.json */; };
 		0B9ACF382BA14FDB00EC0BDE /* Main-D-final.json in Resources */ = {isa = PBXBuildFile; fileRef = 0B9ACF322BA14FDB00EC0BDE /* Main-D-final.json */; };
@@ -80,6 +81,7 @@
 		0B3C29702BA01C3000435B30 /* MyPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageView.swift; sourceTree = "<group>"; };
 		0B3C29722BA01DCE00435B30 /* CustomTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTabView.swift; sourceTree = "<group>"; usesTabs = 0; };
 		0B7646BA2BB13F6100C56D7A /* SurveyButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyButton.swift; sourceTree = "<group>"; };
+		0B9834DB2BC8234700A1457A /* SplashView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashView.swift; sourceTree = "<group>"; };
 		0B9ACF302BA14FDB00EC0BDE /* Main-F-final.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "Main-F-final.json"; sourceTree = "<group>"; };
 		0B9ACF312BA14FDB00EC0BDE /* Main-B-final.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "Main-B-final.json"; sourceTree = "<group>"; };
 		0B9ACF322BA14FDB00EC0BDE /* Main-D-final.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "Main-D-final.json"; sourceTree = "<group>"; };
@@ -273,6 +275,7 @@
 				0B3C296E2BA01C2800435B30 /* HomeView.swift */,
 				0B3C29702BA01C3000435B30 /* MyPageView.swift */,
 				0BF56C922BC39127003ECFB1 /* PickerView.swift */,
+				0B9834DB2BC8234700A1457A /* SplashView.swift */,
 			);
 			path = Presentation;
 			sourceTree = "<group>";
@@ -468,6 +471,7 @@
 				0BC0E5B52BB04BD100FB0330 /* GoalTimeView.swift in Sources */,
 				0BC0E5AB2BB03F8100FB0330 /* OnboardingViewModel.swift in Sources */,
 				0BF56C932BC39127003ECFB1 /* PickerView.swift in Sources */,
+				0B9834DC2BC8234700A1457A /* SplashView.swift in Sources */,
 				0BC0E5B12BB04BA800FB0330 /* SurveyProblemView.swift in Sources */,
 				0B3C29712BA01C3000435B30 /* MyPageView.swift in Sources */,
 				0B3C29732BA01DCE00435B30 /* CustomTabView.swift in Sources */,

--- a/HMH_iOS/HMH_iOS/Global/HMH_iOSApp.swift
+++ b/HMH_iOS/HMH_iOS/Global/HMH_iOSApp.swift
@@ -10,7 +10,7 @@ import SwiftUI
 @main
 struct HMH_iOSApp: App {
     @State private var isLoading: Bool = true
-    @AppStorage("isOnboarding") var isOnboarding : Bool = false
+    @AppStorage("isOnboarding") var isOnboarding : Bool = true
     
     var body: some Scene {
         WindowGroup {

--- a/HMH_iOS/HMH_iOS/Global/HMH_iOSApp.swift
+++ b/HMH_iOS/HMH_iOS/Global/HMH_iOSApp.swift
@@ -9,9 +9,23 @@ import SwiftUI
 
 @main
 struct HMH_iOSApp: App {
+    @State private var isLoading: Bool = true
+    @AppStorage("isOnboarding") var isOnboarding : Bool = true
+    
     var body: some Scene {
         WindowGroup {
-            OnboardingContentView()
+            ZStack {
+                if isLoading {
+                    SplashView(isLoading: $isLoading)
+                } else {
+                    if isOnboarding {
+                       TabBarView()
+                    } else {
+                        OnboardingContentView()
+                    }
+                }
+            }
         }
     }
 }
+        

--- a/HMH_iOS/HMH_iOS/Global/HMH_iOSApp.swift
+++ b/HMH_iOS/HMH_iOS/Global/HMH_iOSApp.swift
@@ -10,7 +10,7 @@ import SwiftUI
 @main
 struct HMH_iOSApp: App {
     @State private var isLoading: Bool = true
-    @AppStorage("isOnboarding") var isOnboarding : Bool = true
+    @AppStorage("isOnboarding") var isOnboarding : Bool = false
     
     var body: some Scene {
         WindowGroup {
@@ -19,7 +19,7 @@ struct HMH_iOSApp: App {
                     SplashView(isLoading: $isLoading)
                 } else {
                     if isOnboarding {
-                       TabBarView()
+                        TabBarView()
                     } else {
                         OnboardingContentView()
                     }
@@ -28,4 +28,4 @@ struct HMH_iOSApp: App {
         }
     }
 }
-        
+

--- a/HMH_iOS/HMH_iOS/Presentation/Onboarding/Views/OnboardingCompleteView.swift
+++ b/HMH_iOS/HMH_iOS/Presentation/Onboarding/Views/OnboardingCompleteView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct OnboardingCompleteView: View {
+    @AppStorage("isOnboarding") var isOnboarding: Bool = true
     
     var body: some View {
         NavigationView {

--- a/HMH_iOS/HMH_iOS/Presentation/SplashView.swift
+++ b/HMH_iOS/HMH_iOS/Presentation/SplashView.swift
@@ -1,0 +1,24 @@
+//
+//  SplashView.swift
+//  HMH_iOS
+//
+//  Created by Seonwoo Kim on 4/11/24.
+//
+
+import SwiftUI
+
+struct SplashView: View {
+    @Binding var isLoading: Bool
+    
+    var body: some View {
+        VStack {}
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(.bluePurpleLine, ignoresSafeAreaEdges: .all)
+            .onAppear {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 1.5, execute: {
+                    isLoading.toggle()
+                })
+            }
+    }
+}
+


### PR DESCRIPTION
## 👾 작업 내용
<!-- 작업한 내용을 간단하게 적어주세요! -->
- Main App 파일에 루트뷰를 바꿔주는 듯한 코드를 넣었습니다.
```swift
    @State private var isLoading: Bool = true
    @AppStorage("isOnboarding") var isOnboarding : Bool = true
```
- AppStorage는 UserDefaults에 Onboarding정보를 저장하기 위해 사용하였습니다.
- SplashView로 바인딩 하여 1.5초가 지나면 isLoading이 toggle되게 하였습니다.
- SplashView는 임의적으로 구현하였습니다.
## 🚀 PR Point
<!-- 주의할 사항이나 같이 고민해볼 부분, 강조하고 싶은 내용 등을 적어주세요! -->
-` @AppStorage("isOnboarding") var isOnboarding : Bool = false`로 되어있어야 맞지만, 앞으로의 작업상 편의를 위하여 main view로 바로 넘어가도록 true로 처리하였습니다.
- CompleteView에서 해당 값을 변경합니다.

## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
|Splash |<img src="https://github.com/Team-HMH/HMH_iOS/assets/95562494/c352d957-8089-4efb-858f-1aa9b018c568" width="35%"> |

## ✅ CheckList
- [x] 오류 없이 빌드되는지 확인
- [x] 로그용 print문 제거
- [x] 불필요한 주석 제거
- [x] 코드 컨벤션 확인

### 🔗 Issue 
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #15 

